### PR TITLE
8633brown patch 1

### DIFF
--- a/tests/SentinelTest.php
+++ b/tests/SentinelTest.php
@@ -525,7 +525,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
             $users        = m::mock('Cartalyst\Sentinel\Users\IlluminateUserRepository'),
             $roles        = m::mock('Cartalyst\Sentinel\Roles\IlluminateRoleRepository'),
             $activations  = m::mock('Cartalyst\Sentinel\Activations\IlluminateActivationRepository'),
-            $dispatcher   = m::mock('Illuminate\Contracts\Events\Dispatcher')
+            $dispatcher   = m::mock('Illuminate\Contracts\Events\Dispatcher')->shouldRecieve('dispatch')
         );
 
         return [$sentinel, $persistences, $users, $roles, $activations, $dispatcher];

--- a/tests/SentinelTest.php
+++ b/tests/SentinelTest.php
@@ -46,7 +46,6 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $users->shouldReceive('create')->once();
 
         $dispatcher->shouldReceive('fire')->twice();
-        $dispatcher->shouldReceive('dispatch')->once();
 
         $sentinel->register([
             'email' => 'foo@example.com',
@@ -61,7 +60,6 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $users->shouldReceive('validForCreation')->once()->andReturn(false);
 
         $dispatcher->shouldReceive('fire')->once();
-        $dispatcher->shouldReceive('dispatch')->once();
 
         $user = $sentinel->register([
             'email' => 'foo@example.com',
@@ -96,7 +94,6 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $activation->shouldReceive('getCode')->once()->andReturn('a_random_code');
 
         $dispatcher->shouldReceive('fire')->times(4);
-        $dispatcher->shouldReceive('dispatch')->once();
 
         $sentinel->registerAndActivate([
             'email'    => 'foo@example.com',
@@ -115,7 +112,6 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $activation->shouldReceive('getCode')->once()->andReturn('a_random_code');
 
         $dispatcher->shouldReceive('fire')->twice();
-        $dispatcher->shouldReceive('dispatch')->once();
 
         $sentinel->activate($user);
     }
@@ -133,7 +129,6 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $activation->shouldReceive('getCode')->once()->andReturn('a_random_code');
 
         $dispatcher->shouldReceive('fire')->twice();
-        $dispatcher->shouldReceive('dispatch')->once();
 
         $sentinel->activate('1');
     }
@@ -154,7 +149,6 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $activation->shouldReceive('getCode')->once()->andReturn('a_random_code');
 
         $dispatcher->shouldReceive('fire')->twice();
-        $dispatcher->shouldReceive('dispatch')->once();
 
         $sentinel->activate($credentials);
     }
@@ -265,7 +259,6 @@ class SentinelTest extends PHPUnit_Framework_TestCase
 
         $dispatcher->shouldReceive('until')->once();
         $dispatcher->shouldReceive('fire')->once();
-        $dispatcher->shouldReceive('dispatch')->once();
 
         $sentinel->authenticate($credentials);
     }
@@ -282,7 +275,6 @@ class SentinelTest extends PHPUnit_Framework_TestCase
 
         $dispatcher->shouldReceive('until')->once();
         $dispatcher->shouldReceive('fire')->once();
-        $dispatcher->shouldReceive('dispatch')->once();
 
         $sentinel->authenticate($user);
     }
@@ -324,7 +316,6 @@ class SentinelTest extends PHPUnit_Framework_TestCase
 
         $dispatcher->shouldReceive('until')->once();
         $dispatcher->shouldReceive('fire')->once();
-        $dispatcher->shouldReceive('dispatch')->once();
 
         $sentinel->authenticateAndRemember($credentials);
     }

--- a/tests/SentinelTest.php
+++ b/tests/SentinelTest.php
@@ -46,6 +46,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $users->shouldReceive('create')->once();
 
         $dispatcher->shouldReceive('fire')->twice();
+        $dispatcher->shouldReceive('dispatch')->once();
 
         $sentinel->register([
             'email' => 'foo@example.com',
@@ -60,6 +61,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $users->shouldReceive('validForCreation')->once()->andReturn(false);
 
         $dispatcher->shouldReceive('fire')->once();
+        $dispatcher->shouldReceive('dispatch')->once();
 
         $user = $sentinel->register([
             'email' => 'foo@example.com',
@@ -94,6 +96,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $activation->shouldReceive('getCode')->once()->andReturn('a_random_code');
 
         $dispatcher->shouldReceive('fire')->times(4);
+        $dispatcher->shouldReceive('dispatch')->once();
 
         $sentinel->registerAndActivate([
             'email'    => 'foo@example.com',
@@ -112,6 +115,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $activation->shouldReceive('getCode')->once()->andReturn('a_random_code');
 
         $dispatcher->shouldReceive('fire')->twice();
+        $dispatcher->shouldReceive('dispatch')->once();
 
         $sentinel->activate($user);
     }
@@ -129,6 +133,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $activation->shouldReceive('getCode')->once()->andReturn('a_random_code');
 
         $dispatcher->shouldReceive('fire')->twice();
+        $dispatcher->shouldReceive('dispatch')->once();
 
         $sentinel->activate('1');
     }
@@ -149,6 +154,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $activation->shouldReceive('getCode')->once()->andReturn('a_random_code');
 
         $dispatcher->shouldReceive('fire')->twice();
+        $dispatcher->shouldReceive('dispatch')->once();
 
         $sentinel->activate($credentials);
     }
@@ -259,6 +265,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
 
         $dispatcher->shouldReceive('until')->once();
         $dispatcher->shouldReceive('fire')->once();
+        $dispatcher->shouldReceive('dispatch')->once();
 
         $sentinel->authenticate($credentials);
     }
@@ -275,6 +282,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
 
         $dispatcher->shouldReceive('until')->once();
         $dispatcher->shouldReceive('fire')->once();
+        $dispatcher->shouldReceive('dispatch')->once();
 
         $sentinel->authenticate($user);
     }
@@ -316,6 +324,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
 
         $dispatcher->shouldReceive('until')->once();
         $dispatcher->shouldReceive('fire')->once();
+        $dispatcher->shouldReceive('dispatch')->once();
 
         $sentinel->authenticateAndRemember($credentials);
     }

--- a/tests/SentinelTest.php
+++ b/tests/SentinelTest.php
@@ -45,7 +45,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $users->shouldReceive('validForCreation')->once()->andReturn(true);
         $users->shouldReceive('create')->once();
 
-        $dispatcher->shouldReceive('fire')->twice();
+        $dispatcher->shouldReceive('dispatch')->twice();
 
         $sentinel->register([
             'email' => 'foo@example.com',
@@ -59,7 +59,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
 
         $users->shouldReceive('validForCreation')->once()->andReturn(false);
 
-        $dispatcher->shouldReceive('fire')->once();
+        $dispatcher->shouldReceive('dispatch')->once();
 
         $user = $sentinel->register([
             'email' => 'foo@example.com',
@@ -93,7 +93,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
 
         $activation->shouldReceive('getCode')->once()->andReturn('a_random_code');
 
-        $dispatcher->shouldReceive('fire')->times(4);
+        $dispatcher->shouldReceive('dispatch')->times(4);
 
         $sentinel->registerAndActivate([
             'email'    => 'foo@example.com',
@@ -111,7 +111,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $activations->shouldReceive('complete')->once()->andReturn(true);
         $activation->shouldReceive('getCode')->once()->andReturn('a_random_code');
 
-        $dispatcher->shouldReceive('fire')->twice();
+        $dispatcher->shouldReceive('dispatch')->twice();
 
         $sentinel->activate($user);
     }
@@ -128,7 +128,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $activations->shouldReceive('complete')->once()->andReturn(true);
         $activation->shouldReceive('getCode')->once()->andReturn('a_random_code');
 
-        $dispatcher->shouldReceive('fire')->twice();
+        $dispatcher->shouldReceive('dispatch')->twice();
 
         $sentinel->activate('1');
     }
@@ -148,7 +148,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $activations->shouldReceive('complete')->once()->andReturn(true);
         $activation->shouldReceive('getCode')->once()->andReturn('a_random_code');
 
-        $dispatcher->shouldReceive('fire')->twice();
+        $dispatcher->shouldReceive('dispatch')->twice();
 
         $sentinel->activate($credentials);
     }
@@ -258,7 +258,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $users->shouldReceive('recordLogin')->once();
 
         $dispatcher->shouldReceive('until')->once();
-        $dispatcher->shouldReceive('fire')->once();
+        $dispatcher->shouldReceive('dispatch')->once();
 
         $sentinel->authenticate($credentials);
     }
@@ -274,7 +274,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $users->shouldReceive('recordLogin')->once();
 
         $dispatcher->shouldReceive('until')->once();
-        $dispatcher->shouldReceive('fire')->once();
+        $dispatcher->shouldReceive('dispatch')->once();
 
         $sentinel->authenticate($user);
     }
@@ -315,7 +315,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $users->shouldReceive('recordLogin')->once();
 
         $dispatcher->shouldReceive('until')->once();
-        $dispatcher->shouldReceive('fire')->once();
+        $dispatcher->shouldReceive('dispatch')->once();
 
         $sentinel->authenticateAndRemember($credentials);
     }

--- a/tests/SentinelTest.php
+++ b/tests/SentinelTest.php
@@ -525,7 +525,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
             $users        = m::mock('Cartalyst\Sentinel\Users\IlluminateUserRepository'),
             $roles        = m::mock('Cartalyst\Sentinel\Roles\IlluminateRoleRepository'),
             $activations  = m::mock('Cartalyst\Sentinel\Activations\IlluminateActivationRepository'),
-            $dispatcher   = m::mock('Illuminate\Contracts\Events\Dispatcher')->shouldRecieve('dispatch')
+            $dispatcher   = m::mock('Illuminate\Contracts\Events\Dispatcher')
         );
 
         return [$sentinel, $persistences, $users, $roles, $activations, $dispatcher];

--- a/tests/ThrottleCheckpointTest.php
+++ b/tests/ThrottleCheckpointTest.php
@@ -130,7 +130,7 @@ class ThrottleCheckpointTest extends PHPUnit_Framework_TestCase
         } catch (ThrottlingException $e) {
             $this->assertEquals(10, $e->getDelay());
             $this->assertEquals('user', $e->getType());
-            $this->assertEquals(Carbon::now()->addSeconds(10), $e->getFree());
+            $this->assertLessThanOrEqual(Carbon::now()->addSeconds(10)->diffInMilliSeconds($e->getFree(), 1000);
         }
     }
 }

--- a/tests/ThrottleCheckpointTest.php
+++ b/tests/ThrottleCheckpointTest.php
@@ -130,7 +130,7 @@ class ThrottleCheckpointTest extends PHPUnit_Framework_TestCase
         } catch (ThrottlingException $e) {
             $this->assertEquals(10, $e->getDelay());
             $this->assertEquals('user', $e->getType());
-            $this->assertLessThanOrEqual(Carbon::now()->addSeconds(10)->diffInMicroseconds($e->getFree()), 10000);
+            $this->assertEquals(Carbon::now()->addSeconds(10), $e->getFree());
         }
     }
 }

--- a/tests/ThrottleCheckpointTest.php
+++ b/tests/ThrottleCheckpointTest.php
@@ -130,7 +130,7 @@ class ThrottleCheckpointTest extends PHPUnit_Framework_TestCase
         } catch (ThrottlingException $e) {
             $this->assertEquals(10, $e->getDelay());
             $this->assertEquals('user', $e->getType());
-            $this->assertLessThanOrEqual(Carbon::now()->addSeconds(10)->diffInMilliSeconds($e->getFree(), 1000));
+            $this->assertLessThanOrEqual(Carbon::now()->addSeconds(10)->diffInMicroseconds($e->getFree(), 10000));
         }
     }
 }

--- a/tests/ThrottleCheckpointTest.php
+++ b/tests/ThrottleCheckpointTest.php
@@ -130,7 +130,7 @@ class ThrottleCheckpointTest extends PHPUnit_Framework_TestCase
         } catch (ThrottlingException $e) {
             $this->assertEquals(10, $e->getDelay());
             $this->assertEquals('user', $e->getType());
-            $this->assertLessThanOrEqual(Carbon::now()->addSeconds(10)->diffInMilliSeconds($e->getFree(), 1000);
+            $this->assertLessThanOrEqual(Carbon::now()->addSeconds(10)->diffInMilliSeconds($e->getFree(), 1000));
         }
     }
 }

--- a/tests/ThrottleCheckpointTest.php
+++ b/tests/ThrottleCheckpointTest.php
@@ -130,7 +130,7 @@ class ThrottleCheckpointTest extends PHPUnit_Framework_TestCase
         } catch (ThrottlingException $e) {
             $this->assertEquals(10, $e->getDelay());
             $this->assertEquals('user', $e->getType());
-            $this->assertEquals(Carbon::now()->addSeconds(10), $e->getFree());
+            $this->assertLessThanOrEqual(10000, Carbon::now()->addSeconds(10)->diffInMicroseconds($e->getFree()));
         }
     }
 }

--- a/tests/ThrottleCheckpointTest.php
+++ b/tests/ThrottleCheckpointTest.php
@@ -130,7 +130,7 @@ class ThrottleCheckpointTest extends PHPUnit_Framework_TestCase
         } catch (ThrottlingException $e) {
             $this->assertEquals(10, $e->getDelay());
             $this->assertEquals('user', $e->getType());
-            $this->assertLessThanOrEqual(Carbon::now()->addSeconds(10)->diffInMicroseconds($e->getFree(), 10000));
+            $this->assertLessThanOrEqual(Carbon::now()->addSeconds(10)->diffInMicroseconds($e->getFree()), 10000);
         }
     }
 }


### PR DESCRIPTION
Illuminate\Contracts\Events\Dispatcher - 'fire' method has been renamed to 'dispatch'
https://laravel.com/docs/5.4/upgrade

time test change to allow 0.01 second difference between values